### PR TITLE
fix php fatal error when no route match.

### DIFF
--- a/src/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -469,6 +469,9 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     protected function getControllerFullClassName()
     {
         $routeMatch           = $this->getApplication()->getMvcEvent()->getRouteMatch();
+        if(!$routeMatch) {
+            throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
+        }
         $controllerIdentifier = $routeMatch->getParam('controller');
         $controllerManager    = $this->getApplicationServiceLocator()->get('ControllerManager');
         $controllerClass      = $controllerManager->get($controllerIdentifier);
@@ -560,6 +563,9 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     public function assertControllerName($controller)
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
+        if(!$routeMatch) {
+            throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
+        }
         $match      = $routeMatch->getParam('controller');
         $match      = strtolower($match);
         $controller = strtolower($controller);
@@ -579,6 +585,9 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     public function assertNotControllerName($controller)
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
+        if(!$routeMatch) {
+            throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
+        }
         $match      = $routeMatch->getParam('controller');
         $match      = strtolower($match);
         $controller = strtolower($controller);
@@ -598,6 +607,9 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     public function assertActionName($action)
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
+        if(!$routeMatch) {
+            throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
+        }
         $match      = $routeMatch->getParam('action');
         $match      = strtolower($match);
         $action     = strtolower($action);
@@ -617,6 +629,9 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     public function assertNotActionName($action)
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
+        if(!$routeMatch) {
+            throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
+        }
         $match      = $routeMatch->getParam('action');
         $match      = strtolower($match);
         $action     = strtolower($action);
@@ -636,6 +651,9 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     public function assertMatchedRouteName($route)
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
+        if(!$routeMatch) {
+            throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
+        }
         $match      = $routeMatch->getMatchedRouteName();
         $match      = strtolower($match);
         $route      = strtolower($route);
@@ -655,6 +673,9 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     public function assertNotMatchedRouteName($route)
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
+        if(!$routeMatch) {
+            throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
+        }
         $match      = $routeMatch->getMatchedRouteName();
         $match      = strtolower($match);
         $route      = strtolower($route);
@@ -664,6 +685,23 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
             );
         }
         $this->assertNotEquals($route, $match);
+    }
+
+    /**
+     * Assert that the application did not match any route
+     */
+    public function assertNoMatchedRoute()
+    {
+        $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
+        if($routeMatch) {
+            $match      = $routeMatch->getMatchedRouteName();
+            $match      = strtolower($match);
+            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+                    'Failed asserting that no route matched, actual matched route name is "%s"',
+                    $match
+            ));
+        }
+        $this->assertNull($routeMatch);
     }
 
     /**

--- a/src/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -469,7 +469,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     protected function getControllerFullClassName()
     {
         $routeMatch           = $this->getApplication()->getMvcEvent()->getRouteMatch();
-        if(!$routeMatch) {
+        if (!$routeMatch) {
             throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
         }
         $controllerIdentifier = $routeMatch->getParam('controller');
@@ -563,7 +563,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     public function assertControllerName($controller)
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
-        if(!$routeMatch) {
+        if (!$routeMatch) {
             throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
         }
         $match      = $routeMatch->getParam('controller');
@@ -585,7 +585,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     public function assertNotControllerName($controller)
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
-        if(!$routeMatch) {
+        if (!$routeMatch) {
             throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
         }
         $match      = $routeMatch->getParam('controller');
@@ -607,7 +607,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     public function assertActionName($action)
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
-        if(!$routeMatch) {
+        if (!$routeMatch) {
             throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
         }
         $match      = $routeMatch->getParam('action');
@@ -629,7 +629,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     public function assertNotActionName($action)
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
-        if(!$routeMatch) {
+        if (!$routeMatch) {
             throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
         }
         $match      = $routeMatch->getParam('action');
@@ -651,7 +651,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     public function assertMatchedRouteName($route)
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
-        if(!$routeMatch) {
+        if (!$routeMatch) {
             throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
         }
         $match      = $routeMatch->getMatchedRouteName();
@@ -673,7 +673,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     public function assertNotMatchedRouteName($route)
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
-        if(!$routeMatch) {
+        if (!$routeMatch) {
             throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
         }
         $match      = $routeMatch->getMatchedRouteName();
@@ -693,7 +693,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     public function assertNoMatchedRoute()
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
-        if($routeMatch) {
+        if ($routeMatch) {
             $match      = $routeMatch->getMatchedRouteName();
             $match      = strtolower($match);
             throw new PHPUnit_Framework_ExpectationFailedException(sprintf(

--- a/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
+++ b/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
@@ -248,6 +248,12 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNotMatchedRouteName('myroute');
     }
 
+    public function testAssertNoMatchedRoute()
+    {
+        $this->dispatch('/invalid');
+        $this->assertNoMatchedRoute();
+    }
+
     /**
      * Sample tests on Application errors events
      */

--- a/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
+++ b/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
@@ -254,6 +254,62 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNoMatchedRoute();
     }
 
+    public function testAssertNoMatchedRouteWithMatchedRoute()
+    {
+        $this->dispatch('/tests');
+        $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
+        $this->assertNoMatchedRoute();
+    }
+
+    public function testControllerNameWithNoRouteMatch()
+    {
+        $this->dispatch('/invalid');
+        $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
+        $this->assertControllerName('something');
+    }
+    
+    public function testNotControllerNameWithNoRouteMatch()
+    {
+        $this->dispatch('/invalid');
+        $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
+        $this->assertNotControllerName('something');
+    }
+    
+    public function testActionNameWithNoRouteMatch()
+    {
+        $this->dispatch('/invalid');
+        $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
+        $this->assertActionName('something');
+    }
+    
+    public function testNotActionNameWithNoRouteMatch()
+    {
+        $this->dispatch('/invalid');
+        $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
+        $this->assertNotActionName('something');
+    }
+    
+    public function testMatchedRouteNameWithNoRouteMatch()
+    {
+        $this->dispatch('/invalid');
+        $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
+        $this->assertMatchedRouteName('something');
+    }
+
+    public function testNotMatchedRouteNameWithNoRouteMatch()
+    {
+        $this->dispatch('/invalid');
+        $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
+        $this->assertNotMatchedRouteName('something');
+    }
+
+    public function testControllerClassWithNoRoutematch()
+    {
+        $this->dispatch('/invalid');
+        $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
+        $this->assertControllerClass('something');
+    }
+
     /**
      * Sample tests on Application errors events
      */

--- a/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
+++ b/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
@@ -267,28 +267,28 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
         $this->assertControllerName('something');
     }
-    
+
     public function testNotControllerNameWithNoRouteMatch()
     {
         $this->dispatch('/invalid');
         $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
         $this->assertNotControllerName('something');
     }
-    
+
     public function testActionNameWithNoRouteMatch()
     {
         $this->dispatch('/invalid');
         $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
         $this->assertActionName('something');
     }
-    
+
     public function testNotActionNameWithNoRouteMatch()
     {
         $this->dispatch('/invalid');
         $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
         $this->assertNotActionName('something');
     }
-    
+
     public function testMatchedRouteNameWithNoRouteMatch()
     {
         $this->dispatch('/invalid');


### PR DESCRIPTION
This adds checks that a route was matched before trying to use the RouteMatch object for further assertions. It also adds a new assertion, testNoRouteMatched(), so you can assert that no route was matched
