### PR TITLE
Fix global state change

### DIFF
--- a/src/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -292,9 +292,13 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
         // force to re-create all components
         $this->application = null;
 
-        // reset server datas
+        // reset server data
         if (!$keepPersistence) {
-            $_SESSION = [];
+            /* Do not create a global session variable if it doesn't already exist.
+               Otherwise calling this function could mark tests risky, as it changes global state. */
+            if (array_key_exists('_SESSION', $GLOBALS)) {
+                $_SESSION = [];
+            }
             $_COOKIE  = [];
         }
 

--- a/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
+++ b/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
@@ -356,4 +356,15 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->dispatch('/custom-response');
         $this->assertResponseStatusCode(999);
     }
+
+    public function testResetDoesNotCreateSessionIfNoSessionExists()
+    {
+        if (!extension_loaded('session')) {
+            $this->markTestSkipped('No session extension loaded');
+        }
+
+        $this->reset();
+
+        $this->assertFalse(array_key_exists('_SESSION', $GLOBALS));
+    }
 }

--- a/test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
+++ b/test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
@@ -549,6 +549,10 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
 
     public function testAssertWithMultiDispatchWithoutPersistence()
     {
+        if (!extension_loaded('session')) {
+            $this->markTestSkipped('No session module loaded');
+        }
+
         $this->dispatch('/tests-persistence');
 
         $controller = $this->getApplicationServiceLocator()
@@ -573,6 +577,10 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
 
     public function testAssertWithMultiDispatchWithPersistence()
     {
+        if (!extension_loaded('session')) {
+            $this->markTestSkipped('No session module loaded');
+        }
+
         $this->dispatch('/tests-persistence');
 
         $controller = $this->getApplicationServiceLocator()


### PR DESCRIPTION
If the session extension is loaded but nothing session related happens at
all, `AbstractControllerTestCase::reset()` changes global state and PHPUnit
is marking the test as risky.

With this PR, zend-test does not change global state if no session is used at all.

Thank you for considering this pull request.
