### PR TITLE
Make error reporting compatible with PHPUnit 5 and PHP 7

### DIFF
--- a/src/PHPUnit/Controller/AbstractConsoleControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractConsoleControllerTestCase.php
@@ -29,13 +29,13 @@ abstract class AbstractConsoleControllerTestCase extends AbstractControllerTestC
     {
         $response = $this->getResponse();
         if (false === stripos($response->getContent(), $match)) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 sprintf(
                     'Failed asserting output CONTAINS content "%s", actual content is "%s"',
                     $match,
                     $response->getContent()
                 )
-            );
+            ));
         }
         $this->assertNotSame(false, stripos($response->getContent(), $match));
     }
@@ -50,10 +50,10 @@ abstract class AbstractConsoleControllerTestCase extends AbstractControllerTestC
     {
         $response = $this->getResponse();
         if (false !== stripos($response->getContent(), $match)) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting output DOES NOT CONTAIN content "%s"',
                 $match
-            ));
+            )));
         }
         $this->assertSame(false, stripos($response->getContent(), $match));
     }

--- a/src/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -65,15 +65,39 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     protected function tearDown()
     {
         Console::overrideIsConsole($this->usedConsoleBackup);
+    }
 
+    /**
+     * Create a failure message.
+     *
+     * If $traceError is true, appends exception details, if any.
+     *
+     * @param string $message
+     * @return string
+     */
+    protected function createFailureMessage($message)
+    {
         if (true !== $this->traceError) {
-            return;
+            return $message;
         }
 
         $exception = $this->getApplication()->getMvcEvent()->getParam('exception');
-        if ($exception instanceof \Exception) {
-            throw $exception;
+        if (! $exception instanceof \Throwable && ! $exception instanceof \Exception) {
+            return $message;
         }
+
+        $messages = [];
+        do {
+            $messages[] = sprintf(
+                "Exception '%s' with message '%s' in %s:%d",
+                get_class($exception),
+                $exception->getMessage(),
+                $exception->getFile(),
+                $exception->getLine()
+            );
+        } while ($exception = $exception->getPrevious());
+
+        return sprintf("%s\n\nExceptions raised:\n%s\n", $message, implode("\n\n", $messages));
     }
 
     /**
@@ -356,9 +380,9 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
         $modulesLoaded = $moduleManager->getModules();
         $list          = array_diff($modules, $modulesLoaded);
         if ($list) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 sprintf('Several modules are not loaded "%s"', implode(', ', $list))
-            );
+            ));
         }
         $this->assertEquals(count($list), 0);
     }
@@ -374,9 +398,9 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
         $modulesLoaded = $moduleManager->getModules();
         $list          = array_intersect($modules, $modulesLoaded);
         if ($list) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 sprintf('Several modules WAS not loaded "%s"', implode(', ', $list))
-            );
+            ));
         }
         $this->assertEquals(count($list), 0);
     }
@@ -410,16 +434,16 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     {
         if ($this->useConsoleRequest) {
             if (!in_array($code, [0, 1])) {
-                throw new PHPUnit_Framework_ExpectationFailedException(
+                throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                     'Console status code assert value must be O (valid) or 1 (error)'
-                );
+                ));
             }
         }
         $match = $this->getResponseStatusCode();
         if ($code != $match) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 sprintf('Failed asserting response code "%s", actual status code is "%s"', $code, $match)
-            );
+            ));
         }
         $this->assertEquals($code, $match);
     }
@@ -433,16 +457,16 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     {
         if ($this->useConsoleRequest) {
             if (!in_array($code, [0, 1])) {
-                throw new PHPUnit_Framework_ExpectationFailedException(
+                throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                     'Console status code assert value must be O (valid) or 1 (error)'
-                );
+                ));
             }
         }
         $match = $this->getResponseStatusCode();
         if ($code == $match) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 sprintf('Failed asserting response code was NOT "%s"', $code)
-            );
+            ));
         }
         $this->assertNotEquals($code, $match);
     }
@@ -457,9 +481,9 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     {
         $exception = $this->getApplication()->getMvcEvent()->getParam('exception');
         if (!$exception) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 'Failed asserting application exception, exception not exist'
-            );
+            ));
         }
         if (true === $this->traceError) {
             // set exception as null because we know and have assert the exception
@@ -478,7 +502,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     {
         $routeMatch           = $this->getApplication()->getMvcEvent()->getRouteMatch();
         if (!$routeMatch) {
-            throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage('No route matched'));
         }
         $controllerIdentifier = $routeMatch->getParam('controller');
         $controllerManager    = $this->getApplicationServiceLocator()->get('ControllerManager');
@@ -499,9 +523,9 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
         $match           = strtolower($match);
         $module          = strtolower($module);
         if ($module != $match) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 sprintf('Failed asserting module name "%s", actual module name is "%s"', $module, $match)
-            );
+            ));
         }
         $this->assertEquals($module, $match);
     }
@@ -518,9 +542,9 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
         $match           = strtolower($match);
         $module          = strtolower($module);
         if ($module == $match) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 sprintf('Failed asserting module was NOT "%s"', $module)
-            );
+            ));
         }
         $this->assertNotEquals($module, $match);
     }
@@ -537,9 +561,9 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
         $match           = strtolower($match);
         $controller      = strtolower($controller);
         if ($controller != $match) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 sprintf('Failed asserting controller class "%s", actual controller class is "%s"', $controller, $match)
-            );
+            ));
         }
         $this->assertEquals($controller, $match);
     }
@@ -556,9 +580,9 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
         $match           = strtolower($match);
         $controller      = strtolower($controller);
         if ($controller == $match) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 sprintf('Failed asserting controller class was NOT "%s"', $controller)
-            );
+            ));
         }
         $this->assertNotEquals($controller, $match);
     }
@@ -572,15 +596,15 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
         if (!$routeMatch) {
-            throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage('No route matched'));
         }
         $match      = $routeMatch->getParam('controller');
         $match      = strtolower($match);
         $controller = strtolower($controller);
         if ($controller != $match) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 sprintf('Failed asserting controller name "%s", actual controller name is "%s"', $controller, $match)
-            );
+            ));
         }
         $this->assertEquals($controller, $match);
     }
@@ -594,15 +618,15 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
         if (!$routeMatch) {
-            throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage('No route matched'));
         }
         $match      = $routeMatch->getParam('controller');
         $match      = strtolower($match);
         $controller = strtolower($controller);
         if ($controller == $match) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 sprintf('Failed asserting controller name was NOT "%s"', $controller)
-            );
+            ));
         }
         $this->assertNotEquals($controller, $match);
     }
@@ -616,15 +640,15 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
         if (!$routeMatch) {
-            throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage('No route matched'));
         }
         $match      = $routeMatch->getParam('action');
         $match      = strtolower($match);
         $action     = strtolower($action);
         if ($action != $match) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 sprintf('Failed asserting action name "%s", actual action name is "%s"', $action, $match)
-            );
+            ));
         }
         $this->assertEquals($action, $match);
     }
@@ -638,15 +662,15 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
         if (!$routeMatch) {
-            throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage('No route matched'));
         }
         $match      = $routeMatch->getParam('action');
         $match      = strtolower($match);
         $action     = strtolower($action);
         if ($action == $match) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 sprintf('Failed asserting action name was NOT "%s"', $action)
-            );
+            ));
         }
         $this->assertNotEquals($action, $match);
     }
@@ -660,15 +684,15 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
         if (!$routeMatch) {
-            throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage('No route matched'));
         }
         $match      = $routeMatch->getMatchedRouteName();
         $match      = strtolower($match);
         $route      = strtolower($route);
         if ($route != $match) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 sprintf('Failed asserting matched route name was "%s", actual matched route name is "%s"', $route, $match)
-            );
+            ));
         }
         $this->assertEquals($route, $match);
     }
@@ -682,15 +706,15 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     {
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
         if (!$routeMatch) {
-            throw new PHPUnit_Framework_ExpectationFailedException('No route matched');
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage('No route matched'));
         }
         $match      = $routeMatch->getMatchedRouteName();
         $match      = strtolower($match);
         $route      = strtolower($route);
         if ($route == $match) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 sprintf('Failed asserting route matched was NOT "%s"', $route)
-            );
+            ));
         }
         $this->assertNotEquals($route, $match);
     }
@@ -704,10 +728,10 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
         if ($routeMatch) {
             $match      = $routeMatch->getMatchedRouteName();
             $match      = strtolower($match);
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting that no route matched, actual matched route name is "%s"',
                 $match
-            ));
+            )));
         }
         $this->assertNull($routeMatch);
     }

--- a/src/PHPUnit/Controller/AbstractHttpControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractHttpControllerTestCase.php
@@ -58,10 +58,10 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     {
         $responseHeader = $this->getResponseHeader($header);
         if (false === $responseHeader) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting response header "%s" found',
                 $header
-            ));
+            )));
         }
         $this->assertNotEquals(false, $responseHeader);
     }
@@ -75,10 +75,10 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     {
         $responseHeader = $this->getResponseHeader($header);
         if (false !== $responseHeader) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting response header "%s" WAS NOT found',
                 $header
-            ));
+            )));
         }
         $this->assertFalse($responseHeader);
     }
@@ -93,10 +93,10 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     {
         $responseHeader = $this->getResponseHeader($header);
         if (!$responseHeader) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting response header, header "%s" doesn\'t exist',
                 $header
-            ));
+            )));
         }
 
         if (!$responseHeader instanceof \ArrayIterator) {
@@ -113,12 +113,12 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
         }
 
         if (!$headerMatched) {
-            throw new \PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new \PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting response header "%s" exists and contains "%s", actual content is "%s"',
                 $header,
                 $match,
                 $currentHeader->getFieldValue()
-            ));
+            )));
         }
 
         $this->assertEquals($match, $currentHeader->getFieldValue());
@@ -134,10 +134,10 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     {
         $responseHeader = $this->getResponseHeader($header);
         if (!$responseHeader) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting response header, header "%s" doesn\'t exist',
                 $header
-            ));
+            )));
         }
 
         if (!$responseHeader instanceof \ArrayIterator) {
@@ -146,11 +146,11 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
 
         foreach ($responseHeader as $currentHeader) {
             if ($match == $currentHeader->getFieldValue()) {
-                throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+                throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                     'Failed asserting response header "%s" DOES NOT CONTAIN "%s"',
                     $header,
                     $match
-                ));
+                )));
             }
         }
 
@@ -167,10 +167,10 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     {
         $responseHeader = $this->getResponseHeader($header);
         if (!$responseHeader) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting response header, header "%s" doesn\'t exist',
                 $header
-            ));
+            )));
         }
 
         if (!$responseHeader instanceof \ArrayIterator) {
@@ -188,12 +188,12 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
         }
 
         if (!$headerMatched) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting response header "%s" exists and matches regex "%s", actual content is "%s"',
                 $header,
                 $pattern,
                 $currentHeader->getFieldValue()
-            ));
+            )));
         }
 
         $this->assertTrue($headerMatched);
@@ -209,10 +209,10 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     {
         $responseHeader = $this->getResponseHeader($header);
         if (!$responseHeader) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting response header, header "%s" doesn\'t exist',
                 $header
-            ));
+            )));
         }
 
         if (!$responseHeader instanceof \ArrayIterator) {
@@ -225,11 +225,11 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
             $headerMatched = (bool) preg_match($pattern, $currentHeader->getFieldValue());
 
             if ($headerMatched) {
-                throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+                throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                     'Failed asserting response header "%s" DOES NOT MATCH regex "%s"',
                     $header,
                     $pattern
-                ));
+                )));
             }
         }
 
@@ -243,9 +243,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     {
         $responseHeader = $this->getResponseHeader('Location');
         if (false === $responseHeader) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 'Failed asserting response is a redirect'
-            );
+            ));
         }
         $this->assertNotEquals(false, $responseHeader);
     }
@@ -257,10 +257,10 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     {
         $responseHeader = $this->getResponseHeader('Location');
         if (false !== $responseHeader) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting response is NOT a redirect, actual redirection is "%s"',
                 $responseHeader->getFieldValue()
-            ));
+            )));
         }
         $this->assertFalse($responseHeader);
     }
@@ -274,16 +274,16 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     {
         $responseHeader = $this->getResponseHeader('Location');
         if (!$responseHeader) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 'Failed asserting response is a redirect'
-            );
+            ));
         }
         if ($url != $responseHeader->getFieldValue()) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting response redirects to "%s", actual redirection is "%s"',
                 $url,
                 $responseHeader->getFieldValue()
-            ));
+            )));
         }
         $this->assertEquals($url, $responseHeader->getFieldValue());
     }
@@ -297,15 +297,15 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     {
         $responseHeader = $this->getResponseHeader('Location');
         if (!$responseHeader) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 'Failed asserting response is a redirect'
-            );
+            ));
         }
         if ($url == $responseHeader->getFieldValue()) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting response redirects to "%s"',
                 $url
-            ));
+            )));
         }
         $this->assertNotEquals($url, $responseHeader->getFieldValue());
     }
@@ -319,16 +319,16 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     {
         $responseHeader = $this->getResponseHeader('Location');
         if (!$responseHeader) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 'Failed asserting response is a redirect'
-            );
+            ));
         }
         if (!preg_match($pattern, $responseHeader->getFieldValue())) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting response redirects to URL MATCHING "%s", actual redirection is "%s"',
                 $pattern,
                 $responseHeader->getFieldValue()
-            ));
+            )));
         }
         $this->assertTrue((bool) preg_match($pattern, $responseHeader->getFieldValue()));
     }
@@ -342,15 +342,15 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     {
         $responseHeader = $this->getResponseHeader('Location');
         if (!$responseHeader) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(
                 'Failed asserting response is a redirect'
-            );
+            ));
         }
         if (preg_match($pattern, $responseHeader->getFieldValue())) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting response DOES NOT redirect to URL MATCHING "%s"',
                 $pattern
-            ));
+            )));
         }
         $this->assertFalse((bool) preg_match($pattern, $responseHeader->getFieldValue()));
     }
@@ -434,10 +434,10 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
         $method = $useXpath ? 'xpathQueryCount' : 'queryCount';
         $match = $this->$method($path);
         if (!$match > 0) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting node DENOTED BY %s EXISTS',
                 $path
-            ));
+            )));
         }
         $this->assertTrue($match > 0);
     }
@@ -473,10 +473,10 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
         $method = $useXpath ? 'xpathQueryCount' : 'queryCount';
         $match  = $this->$method($path);
         if ($match != 0) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting node DENOTED BY %s DOES NOT EXIST',
                 $path
-            ));
+            )));
         }
         $this->assertEquals(0, $match);
     }
@@ -513,12 +513,12 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
         $method = $useXpath ? 'xpathQueryCount' : 'queryCount';
         $match = $this->$method($path);
         if ($match != $count) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting node DENOTED BY %s OCCURS EXACTLY %d times, actually occurs %d times',
                 $path,
                 $count,
                 $match
-            ));
+            )));
         }
         $this->assertEquals($match, $count);
     }
@@ -557,11 +557,11 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
         $method = $useXpath ? 'xpathQueryCount' : 'queryCount';
         $match = $this->$method($path);
         if ($match == $count) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting node DENOTED BY %s DOES NOT OCCUR EXACTLY %d times',
                 $path,
                 $count
-            ));
+            )));
         }
         $this->assertNotEquals($match, $count);
     }
@@ -600,12 +600,12 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
         $method = $useXpath ? 'xpathQueryCount' : 'queryCount';
         $match = $this->$method($path);
         if ($match < $count) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting node DENOTED BY %s OCCURS AT LEAST %d times, actually occurs %d times',
                 $path,
                 $count,
                 $match
-            ));
+            )));
         }
         $this->assertTrue($match >= $count);
     }
@@ -644,12 +644,12 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
         $method = $useXpath ? 'xpathQueryCount' : 'queryCount';
         $match = $this->$method($path);
         if ($match > $count) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting node DENOTED BY %s OCCURS AT MOST %d times, actually occurs %d times',
                 $path,
                 $count,
                 $match
-            ));
+            )));
         }
         $this->assertTrue($match <= $count);
     }
@@ -688,10 +688,10 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
         $result = $this->query($path, $useXpath);
 
         if ($result->count() == 0) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting node DENOTED BY %s EXISTS',
                 $path
-            ));
+            )));
         }
 
         $nodeValues = [];
@@ -705,12 +705,12 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
             $nodeValues[] = $node->nodeValue;
         }
 
-        throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+        throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
             'Failed asserting node denoted by %s CONTAINS content "%s", Contents: [%s]',
             $path,
             $match,
             implode(',', $nodeValues)
-        ));
+        )));
     }
 
     /**
@@ -746,18 +746,18 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     {
         $result = $this->query($path, $useXpath);
         if ($result->count() == 0) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting node DENOTED BY %s EXISTS',
                 $path
-            ));
+            )));
         }
         foreach ($result as $node) {
             if ($node->nodeValue == $match) {
-                throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+                throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                     'Failed asserting node DENOTED BY %s DOES NOT CONTAIN content "%s"',
                     $path,
                     $match
-                ));
+                )));
             }
         }
         $currentValue = $node->nodeValue;
@@ -797,18 +797,18 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     {
         $result = $this->query($path, $useXpath);
         if ($result->count() == 0) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting node DENOTED BY %s EXISTS',
                 $path
-            ));
+            )));
         }
         if (!preg_match($pattern, $result->current()->nodeValue)) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting node denoted by %s CONTAINS content MATCHING "%s", actual content is "%s"',
                 $path,
                 $pattern,
                 $result->current()->nodeValue
-            ));
+            )));
         }
         $this->assertTrue((bool) preg_match($pattern, $result->current()->nodeValue));
     }
@@ -846,17 +846,17 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     {
         $result = $this->query($path, $useXpath);
         if ($result->count() == 0) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting node DENOTED BY %s EXISTS',
                 $path
-            ));
+            )));
         }
         if (preg_match($pattern, $result->current()->nodeValue)) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new PHPUnit_Framework_ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting node DENOTED BY %s DOES NOT CONTAIN content MATCHING "%s"',
                 $path,
                 $pattern
-            ));
+            )));
         }
         $this->assertFalse((bool) preg_match($pattern, $result->current()->nodeValue));
     }


### PR DESCRIPTION
In working on the unit testing tutorial, I discovered two issues with how zend-test reports caught exceptions.

`AbstractControllerTestCase::tearDown()` was testing for an exception in the `MvcEvent`, and, if found, re-throwing it. Unfortunately, this breaks for two reasons:
- In PHP 7, we need to test for `Throwable`, as zend-mvc v2 and v3 now will catch any `Throwable`.
- In PHPUnit 5, exceptions thrown in `tearDown()` are caught and silently discarded. Even passing the verbosity flag during execution will not display their messages.

I found the solution was to create a new method, `createFailureMessage()`, which takes the base message to use as an argument. If no exception is present in the `MvcEvent` _or_ `$traceError` is disabled, we return the message unchanged.  Otherwise, we loop through the exception stack, gathering information (the exception type, the exception message, and the file and line in which the exception was thrown), creating a formatted message to append to the provided message.

Additionally, when testing for an exception, we test against both `Throwable` and `Exception`, to allow usage with either PHP 7 or PHP 5.6.

Interestingly, we've never had any tests for the `traceError` functionality previously. The tests in this patch are not comprehensive, but demonstrate that messages passed through the new message do get the exception details.
