### PR TITLE
Fix multiple literal flags for console tests

### DIFF
--- a/src/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -232,7 +232,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     {
         $request = $this->getRequest();
         if ($this->useConsoleRequest) {
-            preg_match_all('/(--\S+[= ]"[^\s"]*\s*[^\s"]*")|(--\S+=\S+|--\S+\s\S+|\S+)/', $url, $matches);
+            preg_match_all('/(--\S+[= ]"[^\s"]*\s*[^\s"]*")|(\S+)/', $url, $matches);
             $params = str_replace([' "', '"'], ['=', ''], $matches[0]);
             $request->params()->exchangeArray($params);
 

--- a/test/PHPUnit/Controller/AbstractConsoleControllerTestCaseTest.php
+++ b/test/PHPUnit/Controller/AbstractConsoleControllerTestCaseTest.php
@@ -131,4 +131,27 @@ class AbstractConsoleControllerTestCaseTest extends AbstractConsoleControllerTes
         $this->assertEquals("10", $routeMatch->getParam('id'));
         $this->assertEquals("custom text", $routeMatch->getParam('text'));
     }
+
+    public function testAssertMatchedArgumentsWithLiteralFlags()
+    {
+        $this->dispatch('literal --foo --bar');
+        $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
+        $this->assertInstanceOf(RouteMatch::class, $routeMatch, 'Did not receive a route match?');
+        $this->assertMatchedRouteName('arguments-literal');
+        $this->assertTrue($routeMatch->getParam('foo'));
+        $this->assertTrue($routeMatch->getParam('bar'));
+        $this->assertFalse($routeMatch->getParam('optional'));
+        $this->assertNull($routeMatch->getParam('doo'));
+
+        $this->reset();
+
+        $this->dispatch('literal --foo --bar --doo test');
+        $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
+        $this->assertInstanceOf(RouteMatch::class, $routeMatch, 'Did not receive a route match?');
+        $this->assertMatchedRouteName('arguments-literal');
+        $this->assertTrue($routeMatch->getParam('foo'));
+        $this->assertTrue($routeMatch->getParam('bar'));
+        $this->assertFalse($routeMatch->getParam('optional'));
+        $this->assertSame('test', $routeMatch->getParam('doo'));
+    }
 }

--- a/test/_files/Baz/config/module.config.php
+++ b/test/_files/Baz/config/module.config.php
@@ -32,7 +32,17 @@ return array(
                             'action'     => 'console',
                         ),
                     ),
-                )
+                ),
+                'arguments-literal' => array(
+                    'type' => 'simple',
+                    'options' => array(
+                        'route'    => 'literal --foo [--bar] [--doo=] [--optional]',
+                        'defaults' => array(
+                            'controller' => 'baz_index',
+                            'action'     => 'console',
+                        ),
+                    ),
+                ),
             ),
         ),
     ),


### PR DESCRIPTION
It is not possible to test a console route with multiple literal flags.

`$this->dispatch('routename --bar --foo'); // no route match`

I have added a test to demonstrate the problem and fixed the regex.
