### PR TITLE
Move coveralls-test to latest-env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,14 @@ matrix:
         - DEPS=lowest
     - php: 5.6
       env:
-        - EXECUTE_TEST_COVERALLS=true
         - DEPS=locked
         - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
         - PATH="$HOME/.local/bin:$PATH"
     - php: 5.6
       env:
-        - PHPUNIT_VERSION=~5.0
         - DEPS=latest
+        - PHPUNIT_VERSION=~5.0
+        - EXECUTE_TEST_COVERALLS=true
     - php: 7
       env:
         - DEPS=lowest
@@ -67,7 +67,7 @@ notifications:
 before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - travis_retry composer self-update
-  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev satooshi/php-coveralls:^1.0 ; fi
   - composer require --no-update "phpunit/phpunit:$PHPUNIT_VERSION"
 
 install:


### PR DESCRIPTION
The composer require of php-coveralls results in a full update which we don't want if we want to test with the versions mentioned in composer.lock.
Use a stable version of php-coveralls.
Removed --no-update flag again. Otherwise php-coveralls won't get installed at all.
