### PR TITLE
Provide PHPUnit class aliases to other projects implementing `zend-test`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,10 @@
     "autoload": {
         "psr-4": {
             "Zend\\Test\\": "src/"
-        }
+        },
+        "files": [
+            "autoload/phpunit-class-aliases.php"
+        ]
     },
     "require": {
         "php": "^5.6 || ^7.0",
@@ -59,10 +62,7 @@
     "autoload-dev": {
         "psr-4": {
             "ZendTest\\Test\\": "test/"
-        },
-        "files": [
-            "autoload/phpunit-class-aliases.php"
-        ]
+        }
     },
     "scripts": {
         "check": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b44fc98d1af1207c25fc11850511736f",
+    "content-hash": "1296ea1583b0697c7473d6583dff28b0",
     "packages": [
         {
             "name": "container-interop/container-interop",


### PR DESCRIPTION
Since the file `autoload/phpunit-class-aliases.php` is stored within `autoload-dev`, no remote project will ever get those aliases which will cause to problems if they're using PHPUnit in versions less than `6.0`.

We should provide those aliases to them from within `autoload` so there is no need in remote projects to manually add those aliases themselves or by using a creepy composer configuration like:
```php
"autoload-dev": {
    "files": [
        "vendor/zendframework/zend-test/autoload/phpunit-class-aliases.php"
    ]
}
```