### PR TITLE
Prefer expectException over deprecated setExpectedException

### DIFF
--- a/src/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -490,7 +490,8 @@ abstract class AbstractControllerTestCase extends TestCase
             $this->getApplication()->getMvcEvent()->setParam('exception', null);
         }
 
-        if (method_exists($this, 'setExpectedException')) {
+        if (! method_exists($this, 'expectException')) {
+            // For old PHPUnit 4
             $this->setExpectedException($type, $message);
         } else {
             $this->expectException($type);

--- a/test/ExpectedExceptionTrait.php
+++ b/test/ExpectedExceptionTrait.php
@@ -16,7 +16,8 @@ trait ExpectedExceptionTrait
      */
     public function expectedException($exceptionClass, $message = '')
     {
-        if (method_exists($this, 'setExpectedException')) {
+        if (! method_exists($this, 'expectException')) {
+            // For old PHPUnit 4
             $this->setExpectedException($exceptionClass, $message);
             return;
         }


### PR DESCRIPTION
A BC break have been discovered in PHPUnit 5.7.23 in Fedora QA which affects this package
https://apps.fedoraproject.org/koschei/package/php-zendframework-zend-test?collection=f28

```
+ php /usr/bin/phpunit --verbose
PHPUnit 5.7.23 by Sebastian Bergmann and contributors.
Runtime:       PHP 7.2.0RC5
Configuration: /builddir/build/BUILD/zend-test-9665205827ed6ee69f1ef82990362057c789250c/phpunit.xml.dist
..F...F.....F.........F.F.F.F.F..........................FFF..F  63 / 128 ( 49%)
...F..F.F.FFFFFF...FF....FFFFF....FF...........S......F.FF..... 126 / 128 ( 98%)
..                                                              128 / 128 (100%)
Time: 320 ms, Memory: 36.00MB
There were 33 failures:
1) ZendTest\Test\PHPUnit\Controller\AbstractConsoleControllerTestCaseTest::testAssertNotResponseStatusCode
Failed asserting that exception message is empty but is 'Failed asserting response code was NOT "0"'.
2) ZendTest\Test\PHPUnit\Controller\AbstractConsoleControllerTestCaseTest::testNotAssertConsoleOutputContains
Failed asserting that exception message is empty but is 'Failed asserting output DOES NOT CONTAIN content "foo"'.
3) ZendTest\Test\PHPUnit\Controller\AbstractControllerTestCaseTest::testCanNotDefineApplicationConfigWhenApplicationIsBuilt
Failed asserting that exception message is empty but is 'Application config can not be set, the application is already built'.
4) ZendTest\Test\PHPUnit\Controller\AbstractControllerTestCaseTest::testAssertNotModuleName
Failed asserting that exception message is empty but is 'Failed asserting module was NOT "baz"'.
5) ZendTest\Test\PHPUnit\Controller\AbstractControllerTestCaseTest::testAssertNotControllerClass
Failed asserting that exception message is empty but is 'Failed asserting controller class was NOT "indexcontroller"'.
6) ZendTest\Test\PHPUnit\Controller\AbstractControllerTestCaseTest::testAssertNotControllerName
Failed asserting that exception message is empty but is 'Failed asserting controller name was NOT "baz_index"'.
7) ZendTest\Test\PHPUnit\Controller\AbstractControllerTestCaseTest::testAssertNotActionName
Failed asserting that exception message is empty but is 'Failed asserting action name was NOT "unittests"'.
8) ZendTest\Test\PHPUnit\Controller\AbstractControllerTestCaseTest::testAssertNotMatchedRouteName
Failed asserting that exception message is empty but is 'Failed asserting route matched was NOT "myroute"'.
9) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertNotResponseStatusCode
Failed asserting that exception message is empty but is 'Failed asserting response code was NOT "200"'.
10) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertHasResponseHeader
Failed asserting that exception message is empty but is 'Failed asserting response header "Unknow-header" found'.
11) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertNotHasResponseHeader
Failed asserting that exception message is empty but is 'Failed asserting response header "Content-Type" WAS NOT found'.
12) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertNotResponseHeaderContains
Failed asserting that exception message is empty but is 'Failed asserting response header "Content-Type" DOES NOT CONTAIN "text/html"'.
13) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertNotResponseHeaderRegex
Failed asserting that exception message is empty but is 'Failed asserting response header "Content-Type" DOES NOT MATCH regex "#html$#"'.
14) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertNotRedirect
Failed asserting that exception message is empty but is 'Failed asserting response is a redirect'.
15) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertNotRedirectTo
Failed asserting that exception message is empty but is 'Failed asserting response redirects to "http://www.zend.com"'.
16) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertNotRedirectRegex
Failed asserting that exception message is empty but is 'Failed asserting response DOES NOT redirect to URL MATCHING "#zend\.com$#"'.
17) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertQuery
Failed asserting that exception message is empty but is 'Failed asserting node DENOTED BY form#id EXISTS'.
18) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertXpathQuery
Failed asserting that exception message is empty but is 'Failed asserting node DENOTED BY //form[@id="id"] EXISTS'.
19) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertXpathQueryWithBadXpathUsage
Failed asserting that exception message is empty but is 'DOMXPath::query(): Invalid expression'.
20) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertNotQuery
Failed asserting that exception message is empty but is 'Failed asserting node DENOTED BY form#myform DOES NOT EXIST'.
21) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertNotXpathQuery
Failed asserting that exception message is empty but is 'Failed asserting node DENOTED BY //form[@id="myform"] DOES NOT EXIST'.
22) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertNotQueryCount
Failed asserting that exception message is empty but is 'Failed asserting node DENOTED BY div.top DOES NOT OCCUR EXACTLY 3 times'.
23) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertNotXpathQueryCount
Failed asserting that exception message is empty but is 'Failed asserting node DENOTED BY //div[@class="top"] DOES NOT OCCUR EXACTLY 3 times'.
24) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertQueryContentContains
Failed asserting that exception message is empty but is 'Failed asserting node denoted by div#content CONTAINS content "bar", Contents: [foo]'.
25) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertQueryContentContainsWithSecondElement
Failed asserting that exception message is empty but is 'Failed asserting node denoted by div.top CONTAINS content "bar", Contents: [,foo,]'.
26) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertXpathQueryContentContains
Failed asserting that exception message is empty but is 'Failed asserting node denoted by //div[@class="top"] CONTAINS content "bar", Contents: [,foo,]'.
27) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertNotQueryContentContains
Failed asserting that exception message is empty but is 'Failed asserting node DENOTED BY div#content DOES NOT CONTAIN content "foo"'.
28) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertNotXpathQueryContentContains
Failed asserting that exception message is empty but is 'Failed asserting node DENOTED BY //div[@id="content"] DOES NOT CONTAIN content "foo"'.
29) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertNotQueryContentRegex
Failed asserting that exception message is empty but is 'Failed asserting node DENOTED BY div#content DOES NOT CONTAIN content MATCHING "#o{2}#"'.
30) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertNotXpathQueryContentRegex
Failed asserting that exception message is empty but is 'Failed asserting node DENOTED BY //div[@id="content"] DOES NOT CONTAIN content MATCHING "#o{2}#"'.
31) ZendTest\Test\PHPUnit\Controller\AbstractHttpControllerTestCaseTest::testAssertResponseReasonPhrase
Failed asserting that exception message is empty but is 'Failed asserting that two strings are equal.'.
32) ZendTest\Test\PHPUnit\ModuleDependenciesTest::testDependenciesModules
Failed asserting that exception message is empty but is 'Several modules are not loaded "Unknow"'.
33) ZendTest\Test\PHPUnit\ModuleDependenciesTest::testBadDependenciesModules
Failed asserting that exception message is empty but is 'Several modules WAS not loaded "Bar"'.
```

Explanation
* until 5.7.22, setExpectedException with empty message means "don't care about message"
* since 5.7.23, this really means "empty message"

See https://github.com/sebastianbergmann/phpunit/issues/2731

As  @sebastianbergmann considers this "only" as a bug fix, not as a BC break this change is required.

This PR switch to reverse logic, prefer  `expectException` when exists (PHPUnit 5 and 6), and only use setExpectedException as a fallback method for old PHPUnit 4