### PR TITLE
Hotfix #61 - Clear global arrays on setUp

### DIFF
--- a/src/PHPUnit/Controller/AbstractConsoleControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractConsoleControllerTestCase.php
@@ -19,6 +19,14 @@ abstract class AbstractConsoleControllerTestCase extends AbstractControllerTestC
      */
     protected $useConsoleRequest = true;
 
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $_SERVER['args'] = 0;
+        $_SERVER['argv'] = [];
+    }
+
     /**
      * Assert console output contain content (insensible case)
      *

--- a/src/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -51,10 +51,33 @@ abstract class AbstractControllerTestCase extends TestCase
     protected $traceError = true;
 
     /**
+     * Original environemnt
+     *
+     * @var array
+     */
+    protected $originalEnvironment;
+
+    /**
      * Reset the application for isolation
      */
     protected function setUp()
     {
+        $this->originalEnvironment = [
+            'post'   => $_POST,
+            'get'    => $_GET,
+            'cookie' => $_COOKIE,
+            'server' => $_SERVER,
+            'env'    => $_ENV,
+            'files'  => $_FILES,
+        ];
+
+        $_POST   = [];
+        $_GET    = [];
+        $_COOKIE = [];
+        $_SERVER = [];
+        $_ENV    = [];
+        $_FILES  = [];
+
         $this->usedConsoleBackup = Console::isConsole();
         $this->reset();
     }

--- a/src/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -88,6 +88,14 @@ abstract class AbstractControllerTestCase extends TestCase
     protected function tearDown()
     {
         Console::overrideIsConsole($this->usedConsoleBackup);
+
+        // Restore the original environment
+        $_POST   = $this->originalEnvironment['post'];
+        $_GET    = $this->originalEnvironment['get'];
+        $_COOKIE = $this->originalEnvironment['cookie'];
+        $_SERVER = $this->originalEnvironment['server'];
+        $_ENV    = $this->originalEnvironment['env'];
+        $_FILES  = $this->originalEnvironment['files'];
     }
 
     /**

--- a/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
+++ b/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
@@ -8,6 +8,7 @@
  */
 namespace ZendTest\Test\PHPUnit\Controller;
 
+use Generator;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamWrapper;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -513,5 +514,25 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
     {
         $this->dispatch('/tests', 'DELETE', ['foo' => 'bar']);
         $this->assertEquals('foo=bar', $this->getRequest()->getQuery()->toString());
+    }
+
+    /**
+     * @return Generator
+     */
+    public function routeParam()
+    {
+        yield 'phpunit' => ['phpunit'];
+        yield 'param' => ['param'];
+    }
+
+    /**
+     * @dataProvider routeParam
+     *
+     * @param string $param
+     */
+    public function testRequestWithRouteParam($param)
+    {
+        $this->dispatch(sprintf('/with-param/%s', $param));
+        $this->assertResponseStatusCode(200);
     }
 }

--- a/test/_files/Baz/config/module.config.php
+++ b/test/_files/Baz/config/module.config.php
@@ -121,6 +121,16 @@ return [
                     ],
                 ],
             ],
+            'parametrized' => [
+                'type' => 'segment',
+                'options' => [
+                    'route'    => '/with-param/:param',
+                    'defaults' => [
+                        'controller' => 'baz_index',
+                        'action'     => 'unittests',
+                    ],
+                ],
+            ],
         ],
     ],
     'controllers' => [


### PR DESCRIPTION
Fixes #61

As described in #61 in case of request uri contains "phpunit" response is always 404, because request is wrongly created from global arrays with all PHPUnit request data etc.

I think we should clear all global arrays when we run these integration tests.
I'm not sure if it has any impact on current users. All our tests pass with these changes. It would be nice to test it with some applications.

We have to set `args` (and `argv` for consistency) because `args` is checked on constucting console request:
https://github.com/zendframework/zend-console/blob/master/src/Request.php#L43-L48
and here we got before all params passed to phpunit runner.

/cc @Scyt8l3 - would you be able to test that branch with your application to check if all works correctly? Thanks!

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.