### PR TITLE
Revert #66 - clearing global arrays on setUp - fixes #71

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,6 @@
         "slack": "https://zendframework-slack.herokuapp.com",
         "forum": "https://discourse.zendframework.com/c/questions/components"
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/webimpress/zend-http"
-        }
-    ],
     "require": {
         "php": "^5.6 || ^7.0",
         "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
@@ -28,7 +22,7 @@
         "zendframework/zend-console": "^2.6",
         "zendframework/zend-dom": "^2.6",
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
-        "zendframework/zend-http": "dev-hotfix/base-url-console-request as 2.8.3",
+        "zendframework/zend-http": "^2.8.3",
         "zendframework/zend-mvc": "^3.0",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "zendframework/zend-stdlib": "^2.7 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,12 @@
         "slack": "https://zendframework-slack.herokuapp.com",
         "forum": "https://discourse.zendframework.com/c/questions/components"
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-http"
+        }
+    ],
     "require": {
         "php": "^5.6 || ^7.0",
         "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
@@ -22,7 +28,7 @@
         "zendframework/zend-console": "^2.6",
         "zendframework/zend-dom": "^2.6",
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
-        "zendframework/zend-http": "^2.5.4",
+        "zendframework/zend-http": "dev-hotfix/base-url-console-request as 2.8.3",
         "zendframework/zend-mvc": "^3.0",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "zendframework/zend-stdlib": "^2.7 || ^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f2dd7c9dac11ee2f0d5998fa1ddcdce",
+    "content-hash": "bf86eb359734daf37a5f184d6a328b1b",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -1753,11 +1753,17 @@
         },
         {
             "name": "zendframework/zend-http",
-            "version": "dev-hotfix/base-url-console-request",
+            "version": "2.8.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webimpress/zend-http",
-                "reference": "bedb5c8895f2dd766175584dad74fac987cd9024"
+                "url": "https://github.com/zendframework/zend-http.git",
+                "reference": "e70ed2a51f37b848c8c3829739d1b1f803854ffa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-http/zipball/e70ed2a51f37b848c8c3829739d1b1f803854ffa",
+                "reference": "e70ed2a51f37b848c8c3829739d1b1f803854ffa",
+                "shasum": ""
             },
             "require": {
                 "php": "^5.6 || ^7.0",
@@ -1786,49 +1792,19 @@
                     "Zend\\Http\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "ZendTest\\Http\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "@cs-check",
-                    "@test"
-                ],
-                "cs-check": [
-                    "phpcs"
-                ],
-                "cs-fix": [
-                    "phpcbf"
-                ],
-                "test": [
-                    "phpunit --colors=always"
-                ],
-                "test-coverage": [
-                    "phpunit --colors=always --coverage-clover clover.xml"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
             "description": "Provides an easy interface for performing Hyper-Text Transfer Protocol (HTTP) requests",
             "keywords": [
-                "HTTP client",
+                "ZendFramework",
                 "http",
+                "http client",
                 "zend",
-                "zendframework",
                 "zf"
             ],
-            "support": {
-                "docs": "https://docs.zendframework.com/zend-http/",
-                "issues": "https://github.com/zendframework/zend-http/issues",
-                "source": "https://github.com/zendframework/zend-http",
-                "rss": "https://github.com/zendframework/zend-http/releases.atom",
-                "chat": "https://zendframework-slack.herokuapp.com",
-                "forum": "https://discourse.zendframework.com/c/questions/components"
-            },
-            "time": "2018-12-25T13:40:16+00:00"
+            "time": "2019-01-08T15:55:38+00:00"
         },
         {
             "name": "zendframework/zend-json",
@@ -3121,18 +3097,9 @@
             "time": "2018-04-30T14:55:10+00:00"
         }
     ],
-    "aliases": [
-        {
-            "alias": "2.8.3",
-            "alias_normalized": "2.8.3.0",
-            "version": "dev-hotfix/base-url-console-request",
-            "package": "zendframework/zend-http"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "zendframework/zend-http": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "57ca2b6b2586947421f5771ecd49e9c8",
+    "content-hash": "0f2dd7c9dac11ee2f0d5998fa1ddcdce",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -1753,17 +1753,11 @@
         },
         {
             "name": "zendframework/zend-http",
-            "version": "2.8.2",
+            "version": "dev-hotfix/base-url-console-request",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-http.git",
-                "reference": "2c8aed3d25522618573194e7cc51351f8cd4a45b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-http/zipball/2c8aed3d25522618573194e7cc51351f8cd4a45b",
-                "reference": "2c8aed3d25522618573194e7cc51351f8cd4a45b",
-                "shasum": ""
+                "url": "https://github.com/webimpress/zend-http",
+                "reference": "bedb5c8895f2dd766175584dad74fac987cd9024"
             },
             "require": {
                 "php": "^5.6 || ^7.0",
@@ -1792,19 +1786,49 @@
                     "Zend\\Http\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Http\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@cs-check",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --colors=always --coverage-clover clover.xml"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
             "description": "Provides an easy interface for performing Hyper-Text Transfer Protocol (HTTP) requests",
             "keywords": [
-                "ZendFramework",
+                "HTTP client",
                 "http",
-                "http client",
                 "zend",
+                "zendframework",
                 "zf"
             ],
-            "time": "2018-08-13T18:47:03+00:00"
+            "support": {
+                "docs": "https://docs.zendframework.com/zend-http/",
+                "issues": "https://github.com/zendframework/zend-http/issues",
+                "source": "https://github.com/zendframework/zend-http",
+                "rss": "https://github.com/zendframework/zend-http/releases.atom",
+                "chat": "https://zendframework-slack.herokuapp.com",
+                "forum": "https://discourse.zendframework.com/c/questions/components"
+            },
+            "time": "2018-12-25T13:40:16+00:00"
         },
         {
             "name": "zendframework/zend-json",
@@ -3097,9 +3121,18 @@
             "time": "2018-04-30T14:55:10+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "2.8.3",
+            "alias_normalized": "2.8.3.0",
+            "version": "dev-hotfix/base-url-console-request",
+            "package": "zendframework/zend-http"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "zendframework/zend-http": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/PHPUnit/Controller/AbstractConsoleControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractConsoleControllerTestCase.php
@@ -19,14 +19,6 @@ abstract class AbstractConsoleControllerTestCase extends AbstractControllerTestC
      */
     protected $useConsoleRequest = true;
 
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $_SERVER['args'] = 0;
-        $_SERVER['argv'] = [];
-    }
-
     /**
      * Assert console output contain content (insensible case)
      *

--- a/src/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -51,33 +51,10 @@ abstract class AbstractControllerTestCase extends TestCase
     protected $traceError = true;
 
     /**
-     * Original environemnt
-     *
-     * @var array
-     */
-    protected $originalEnvironment;
-
-    /**
      * Reset the application for isolation
      */
     protected function setUp()
     {
-        $this->originalEnvironment = [
-            'post'   => $_POST,
-            'get'    => $_GET,
-            'cookie' => $_COOKIE,
-            'server' => $_SERVER,
-            'env'    => $_ENV,
-            'files'  => $_FILES,
-        ];
-
-        $_POST   = [];
-        $_GET    = [];
-        $_COOKIE = [];
-        $_SERVER = [];
-        $_ENV    = [];
-        $_FILES  = [];
-
         $this->usedConsoleBackup = Console::isConsole();
         $this->reset();
     }
@@ -88,14 +65,6 @@ abstract class AbstractControllerTestCase extends TestCase
     protected function tearDown()
     {
         Console::overrideIsConsole($this->usedConsoleBackup);
-
-        // Restore the original environment
-        $_POST   = $this->originalEnvironment['post'];
-        $_GET    = $this->originalEnvironment['get'];
-        $_COOKIE = $this->originalEnvironment['cookie'];
-        $_SERVER = $this->originalEnvironment['server'];
-        $_ENV    = $this->originalEnvironment['env'];
-        $_FILES  = $this->originalEnvironment['files'];
 
         // Prevent memory leak
         $this->reset();


### PR DESCRIPTION
Fixes: #71, revert #66 (keep the test).

Update to `zend-http` with changes for correct detecting base url, see: https://github.com/zendframework/zend-http/pull/165

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.
