### PR TITLE
Update AbstractControllerTestCase.php

### DIFF
--- a/src/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -304,6 +304,14 @@ abstract class AbstractControllerTestCase extends TestCase
 
         $this->url($url, $method, $params);
         $this->getApplication()->run();
+        
+        if (true !== $this->traceError) {
+            return;
+        }
+        $exception = $this->getApplication()->getMvcEvent()->getParam('exception');
+        if ($exception instanceof \Exception) {
+            throw $exception;
+        }
     }
 
     /**


### PR DESCRIPTION
This is the solution to $this->expectExceptionMessage not working in controller test like this :

```
$this->expectExceptionMessage("some exception message");
$this->dispatch("/", 'GET');
```



